### PR TITLE
Add Ignite (Flask SaaS Boilerplate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ List of SaaS boilerplates (starter kits) by stack
 
 - Easy Serverless SaaS boilerplate. Open Source. https://easysaasboilerplate.com/
 - SaaS Forge. Open Source. https://www.saasforge.dev/
+- Ignite (SaaS Boilerplate). Open Source. https://github.com/sumukh/ignite
 - Flask App Builder. Open Source. https://github.com/dpgaspar/Flask-AppBuilder
 
 


### PR DESCRIPTION
Adding Ignite, a SaaS boilerplate that comes with [Fullstack Flask](https://newline.co/fullstack-flask)