### PR TITLE
chore: add next-supabase-stripe-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,4 @@ List of SaaS boilerplates (starter kits) by stack
 - Bedrock. Next.js. https://bedrock.mxstbr.com/
 - GeniePy (Python & Starlette) https://geniepy.com
 - Next.js Subscription Payments Starter by Vercel - https://github.com/vercel/nextjs-subscription-payments
+- Next.js Supabase Stripe Starter - https://github.com/KolbySisk/next-supabase-stripe-starter


### PR DESCRIPTION
Adds [next-supabase-stripe-starter](https://github.com/KolbySisk/next-supabase-stripe-starter) to the list.