### PR TITLE
update saas-starter-kit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ List of SaaS boilerplates (starter kits) by stack
 - Volca https://volca.io
 - Enterprise-ready SaaS Starter Kit. Open Source. https://github.com/boxyhq/saas-starter-kit
 - Supastarter - https://supastarter.dev/
-- SAAS-Starter-Kit-Pro - https://github.com/Saas-Starter-Kit/SAAS-Starter-Kit-Pro
+- SAAS-Starter-Kit - https://github.com/Saas-Starter-Kit/Saas-Kit-prisma
 - Saas UI Pro - https://saas-ui.dev
 - Modern MERN - https://modernmern.com
 - Usenextbase -  https://usenextbase.com


### PR DESCRIPTION
The Github link to Saas-Starter-Kit-Pro links to an archived repo. They provide a link to an active repo, where they proceed with the work. I changed the link to this new repo