### PR TITLE
[Python] Add FastAPI category

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 
 # Python
 
+## FastAPI
+
+- FastSaaS - https://www.fast-saas.com/
+
 ## Django
 
 - Carrot Seed - https://www.cnc.io/en/seed


### PR DESCRIPTION
Hello !

FastAPI just overtook Django as most use Python web Framework in the 2025 annual State of Python developer survey: https://blog.jetbrains.com/pycharm/2025/08/the-state-of-python-2025/

I think FastAPI deserves some love and its own category, here is it in this PR, with (disclaimer) my SaaS boilerplate

<img width="1600" height="1355" alt="image" src="https://github.com/user-attachments/assets/40d7404a-e44c-4c25-8516-d133eba950fd" />

