### PR TITLE
Add Fabrk to Next.js section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 - Bones - [bones.sh](https://bones.sh)
 - Builderkit.ai - https://www.builderkit.ai
 - Dirstarter - https://dirstarter.com/?utm_source=awesome-saas-boilerplates
+- Fabrk - https://fabrk.dev
 - Frontend Accelerator - https://FrontendAccelerator.com/?utm_source=awesome-saas-boilerplates
 - Indie Kit - https://indiekit.pro/
 - Kokonut - https://kokonut.dev/


### PR DESCRIPTION
Adding Fabrk to the Next.js section.

**Entry:** `- Fabrk - https://fabrk.dev`

**Details:**
- Terminal-aesthetic Next.js 16 boilerplate
- Stack: Next.js 16, React 19, TypeScript, Prisma 7, NextAuth v5
- Multi-provider payments (Stripe, Polar, Lemonsqueezy)
- 70+ components, 18 themes

Closes #168