### PR TITLE
Add Stacknaut to Node.js section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 - shadcn/pro - https://shadcnpro.com/
 - ShipMySaaS https://shipmysaas.com
 - StarterSaaS - https://www.startersaas.com/
+- Stacknaut - https://stacknaut.com
 - StartKit.AI - https://startkit.ai
 - Supastarter - https://supastarter.dev/
 - Turbojet https://www.turbojet.co/


### PR DESCRIPTION
Adding [Stacknaut](https://stacknaut.com) — a production-grade SaaS starter kit (Vue + Fastify + PostgreSQL) with auth, billing, and one-command deploy to Hetzner. Built for indie developers.