### PR TITLE
Add LastSaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 
 - Autostrada. [https://autostrada.dev/](https://autostrada.dev/?utm_source=awesome-saas-boilerplates&utm_medium=catalog)
 - GoShip -https://goship.run/
+- LastSaaS. Go + React + MongoDB. **Open Source** [https://github.com/jonradoff/lastsaas](https://github.com/jonradoff/lastsaas) [![Stars](https://img.shields.io/github/stars/jonradoff/lastsaas.svg)](https://github.com/jonradoff/lastsaas)
 - SaaS Startup Kit. Golang - **Open Source** https://saasstartupkit.com/
 
 ## Ruby on Rails


### PR DESCRIPTION
## Summary

- Adds [LastSaaS](https://github.com/jonradoff/lastsaas) to the **Go** section
- Open-source AI-native SaaS platform foundation built with Go + React + TypeScript + MongoDB
- Features: multi-tenant auth, Stripe billing, white-label branding, MCP server (26 tools), webhooks, API keys, admin dashboard
- MIT license