### PR TITLE
Add FounderKit — Next.js 16 SaaS boilerplate with auth, payments, admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 
 ## Next.js
 
+- FounderKit - Next.js 16 SaaS boilerplate with Clerk auth, Stripe subscriptions, admin panel, React Email templates, MDX blog, and OG images. $99 one-time. https://founderkit-eta.vercel.app
 - Agentic React Template - **Open Source** Agent-testable SaaS starter with Next.js 16 + shadcn/ui + Tailwind CSS [https://github.com/iscale-llc/agentic-react-nextjs-shadcn](https://github.com/iscale-llc/agentic-react-nextjs-shadcn) [![Stars](https://img.shields.io/github/stars/iscale-llc/agentic-react-nextjs-shadcn.svg)](https://github.com/iscale-llc/agentic-react-nextjs-shadcn)
 - All-In-One https://allinonedev.com
 - Appliful - https://appliful.com/


### PR DESCRIPTION
## Adding FounderKit

**FounderKit** — production-ready Next.js 16 SaaS boilerplate.

- **URL**: https://founderkit-eta.vercel.app
- **Section**: Next.js
- **Price**: $99 one-time

**Stack:**
- Next.js 16 (App Router) + TypeScript
- Clerk (auth — social OAuth, magic links)
- Stripe (subscriptions + webhooks)
- Drizzle ORM + PostgreSQL
- Resend + React Email (4 transactional templates)
- Admin panel with MRR stats
- MDX Blog
- Dynamic OG image generation
- Waitlist mode + Demo mode

Actively maintained, built in 2026.