### PR TITLE
Add Next.js SaaS Boilerplate under React > Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 - marblism - https://www.marblism.com/
 - Modern MERN - https://modernmern.com
 - Next.js Boilerplate SaaS - https://nextjs-boilerplate.com/pro-saas-starter-kit
+- Next.js SaaS Boilerplate - **Open Source** Next.js 16 starter with auth (Better Auth), Stripe billing, admin dashboard, blog CMS, RBAC, email system, and 50+ shadcn/ui components [https://github.com/habibjutt/nextjs_boilerplate](https://github.com/habibjutt/nextjs_boilerplate) [![Stars](https://img.shields.io/github/stars/habibjutt/nextjs_boilerplate.svg)](https://github.com/habibjutt/nextjs_boilerplate)
 - Nextacular. **Open Source**. https://nextacular.co
 - Nextless JS https://nextlessjs.com
 - NextReady - https://nextready.dev


### PR DESCRIPTION
Adding [Next.js SaaS Boilerplate](https://github.com/habibjutt/nextjs_boilerplate) to the React > Next.js section.

It's a free, open-source Next.js 16 starter for building SaaS products. The stack includes:

- Better Auth for authentication (email, OAuth, 2FA)
- Stripe for billing and subscriptions
- Admin dashboard with RBAC
- Blog CMS with MDX
- Email system via Resend + React Email
- 50+ shadcn/ui components
- Prisma + PostgreSQL

I placed it alphabetically after "Next.js Boilerplate SaaS" and followed the existing entry format. Happy to adjust if needed.