### PR TITLE
Add The Swift Kit to Rare frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 - Flutter - [https://www.flutterboilerplate.com](https://www.flutterboilerplate.com?utm_source=awesome-saas-boilerplates)
 - Quapp: Quasar + Appwrite https://www.quapp.dev/
 - Swift Maker - https://swiftmaker.dev/
+- The Swift Kit - SwiftUI iOS boilerplate with Supabase, RevenueCat, OpenAI, TelemetryDeck, and a centralized 5-layer design system. https://theswiftk.it.com/
 
 # Deployment & Infrastructure
 


### PR DESCRIPTION
Hi! Thanks for maintaining this list.

Adding **The Swift Kit** — a SwiftUI iOS boilerplate that fits the same niche as Swift Maker (already on the list).

**Entry:**
- The Swift Kit - SwiftUI iOS boilerplate with Supabase, RevenueCat, OpenAI, TelemetryDeck, and a centralized 5-layer design system. https://theswiftk.it.com/

**Why it fits:**
- Production-ready SaaS boilerplate (paid, lifetime updates, commercial license)
- 100+ reusable components, interactive setup CLI, feature flags, 3 onboarding templates, paywall templates, AI integration
- iOS 16+ (with iOS 26 Liquid Glass support)
- Used by 50+ indie iOS makers

Placed alphabetically before Swift Maker in the **Rare frameworks** section. Happy to move it elsewhere if you'd prefer a dedicated **iOS / Swift** section — let me know.

Thanks!