### PR TITLE
Add The Flutter Kit to Rare frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 - Flutter - [https://www.flutterboilerplate.com](https://www.flutterboilerplate.com?utm_source=awesome-saas-boilerplates)
 - Quapp: Quasar + Appwrite https://www.quapp.dev/
 - Swift Maker - https://swiftmaker.dev/
+- The Flutter Kit - Cross-platform Flutter boilerplate with Firebase Auth, RevenueCat subscriptions, OpenAI integration, push notifications, Material 3 design system, and BLoC architecture. https://theflutterk.it.com/
 - The Swift Kit - SwiftUI iOS boilerplate with Supabase, RevenueCat, OpenAI, TelemetryDeck, and a centralized 5-layer design system. https://theswiftk.it.com/
 
 # Deployment & Infrastructure


### PR DESCRIPTION
Adds **The Flutter Kit** to the `Rare frameworks` section, alphabetized between `Swift Maker` and `The Swift Kit`.

The Flutter Kit is a production-ready cross-platform Flutter boilerplate covering iOS, Android, Web, macOS, Windows, and Linux. It ships with:

- Firebase Authentication
- RevenueCat subscriptions
- OpenAI / ChatGPT integration
- Push notifications + Firebase Analytics
- Material 3 design system
- BLoC architecture
- Onboarding & paywall templates

Site: https://theflutterk.it.com/

Same maintainer / sister product to `The Swift Kit` (already listed). Format matches the surrounding entries exactly.