### PR TITLE
Add GeoInfomatic (production Flask freemium example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 ## Other
 
 
-- [GeoInfomatic — Living Zone Accessibility](https://geoinfomatic.pythonanywhere.com) - Production Flask SaaS (Korean neighborhood isochrone analyzer). Freemium model: 5 free analyses/day, $7/month Pro for unlimited + PDF reports + multi-point comparison. Flask + Leaflet + Toss Payments. Solo-built on PythonAnywhere free tier.
+- [GeoInfomatic](https://geoinfomatic.pythonanywhere.com)
 - Serverless SaaS. React. https://serverless.page
 - SUB - React, Typescript, Tailwind CSS, Firebase and Stripe - https://getsub.dev
 - TurboStarter https://turbostarter.dev

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 
 ## Other
 
+
+- [GeoInfomatic — Living Zone Accessibility](https://geoinfomatic.pythonanywhere.com) - Production Flask SaaS (Korean neighborhood isochrone analyzer). Freemium model: 5 free analyses/day, $7/month Pro for unlimited + PDF reports + multi-point comparison. Flask + Leaflet + Toss Payments. Solo-built on PythonAnywhere free tier.
 - Serverless SaaS. React. https://serverless.page
 - SUB - React, Typescript, Tailwind CSS, Firebase and Stripe - https://getsub.dev
 - TurboStarter https://turbostarter.dev


### PR DESCRIPTION
Adds **GeoInfomatic** — a Flask-based bootstrapped SaaS in production.

- URL: https://geoinfomatic.pythonanywhere.com
- Model: Freemium (5 free/day, $7/mo Pro)
- Stack: Flask + Leaflet on PythonAnywhere free tier, Toss Payments for Korean subscriptions

Flask isn't FastAPI but Python SaaS — happy to revise placement (perhaps a Flask section, or Other).
