### PR TITLE
add Next.js boilerplate: ShipNext

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 - LaunchFa.st https://launchfa.st/?utm_source=awesome-saas-boilerplates
 - Mkdirs - https://mkdirs.com
 - MkSaaS - https://mksaas.com
+- ShipNext - https://shipnext.pro
 - Next 14 FullStack - https://thesaasfactory.dev
 - Next Starter AI - https://nextstarter.ai
 - Next.js Boilerplate - **Open Source** [https://github.com/ixartz/Next-js-Boilerplate](https://github.com/ixartz/Next-js-Boilerplate) [![Stars](https://img.shields.io/github/stars/ixartz/Next-js-Boilerplate.svg)](https://github.com/ixartz/Next-js-Boilerplate)


### PR DESCRIPTION
Hi! Adding [ShipNext](https://shipnext.pro) to the Next.js boilerplates section.

Name: ShipNext
URL: https://shipnext.pro
Stack: Next.js 16, Stripe, S3, Resend, Drizzle, Resend, Better-Auth, ...
Price: $99 one-time
Placed alphabetically among existing entries in the React > Next.js section. Thanks for maintaining this list!