### PR TITLE
Add SaaSLaunch - Next.js + Supabase + Stripe SaaS boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 - Rocketlaunch - https://www.rocket-launch.dev/
 - SaaS AI - [saasai.dev](https://saasai.dev)
 - SaaS Kit - **Open Sourse** https://saaskit.one/
+- SaaSLaunch - https://saaslaunch.dev/?utm_source=awesome-saas-boilerplates
 - SaasRock - https://saasrock.com
 - Shaker's Kit - https://shakersk.it
 - ShipAI.today - https://shipai.today/


### PR DESCRIPTION
Adds [SaaSLaunch](https://saaslaunch.dev) to the Next.js section.

**Description:** SaaSLaunch is a Next.js 14 (App Router) SaaS boilerplate with Supabase auth, Stripe/Dodo Payments subscriptions, shadcn/ui, i18n, SEO defaults, and pre-wired legal pages. $99 one-time, lifetime updates within the major version.

**Why it fits this list:** Same category as the existing Next.js boilerplate entries (Shipfa.st, Indie Kit, Makerkit, etc.). Inserted alphabetically between `SaaS Kit` and `SaasRock`. Description follows the existing `- Name - URL` style, including the `?utm_source=awesome-saas-boilerplates` parameter used by other recent entries in this section.