### PR TITLE
Add SaaS Starter Lite to NestJS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 ## NestJs
 
 - Launchnow https://www.launchnow.pro/
+- SaaS Starter Lite - **Open Source** NestJS + Angular SaaS boilerplate with JWT/OAuth/2FA auth, Stripe payments, multi-tenancy, RBAC, Docker, and Terraform. https://github.com/sayahweb2-png/saas-starter-lite [![Stars](https://img.shields.io/github/stars/sayahweb2-png/saas-starter-lite.svg)](https://github.com/sayahweb2-png/saas-starter-lite)
 - SYNDROM https://syndrom.io/
 
 ## Node.js


### PR DESCRIPTION
## What is this?

Adding [SaaS Starter Lite](https://github.com/sayahweb2-png/saas-starter-lite) — a free, open-source (MIT) NestJS + Angular SaaS boilerplate — to the NestJS section.

## Features

- NestJS backend + Angular frontend
- JWT/OAuth/2FA authentication
- Stripe payments integration
- Multi-tenancy & RBAC
- BullMQ job queues
- Docker & Terraform deployment
- 55+ tests

**GitHub:** https://github.com/sayahweb2-png/saas-starter-lite
**Demo:** https://demo.cloudrix.io
**License:** MIT