### PR TITLE
Add CreditKit to React/Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 - BoilerPro - https://boilerpro.co
 - Bones - [bones.sh](https://bones.sh)
 - Builderkit.ai - https://www.builderkit.ai
+- CreditKit - Next.js, Supabase, and Stripe starter with a production-ready usage-credits and billing engine (atomic credit spend, idempotent Stripe webhooks, refund-on-failure worker) https://youngalgy.com/creditkit
 - Dirstarter - https://dirstarter.com/?utm_source=awesome-saas-boilerplates
 - Frontend Accelerator - https://FrontendAccelerator.com/?utm_source=awesome-saas-boilerplates
 - Indie Kit - https://indiekit.pro/


### PR DESCRIPTION
Adds CreditKit: a Next.js, Supabase, and Stripe starter that ships the usage-credits and billing layer AI apps actually need (atomic credit spend that can't overdraw, idempotent Stripe webhook grants, a background worker that refunds credits on job failure).

https://youngalgy.com/creditkit