### PR TITLE
Add ShipAnvil to Symfony section

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 ## Symfony
 
 - Parthenon **Open Source** - https://getparthenon.com
+- ShipAnvil - https://shipanvil.com
 
 ## WordPress
 


### PR DESCRIPTION
Adds ShipAnvil to the Symfony section, which currently lists one entry.

- **ShipAnvil** (https://shipanvil.com), a production-grade SaaS starter for Symfony 7.4 LTS: auth with TOTP 2FA and magic links, billing on Stripe **and** Lemon Squeezy behind one interface, teams/multi-tenancy with isolation tests, hand-rolled admin, transactional emails. PHPStan at level max with no baseline, and a suite that replays full billing cycles from signed webhook fixtures. No Node.js. Public live demo on the landing page.

Kept to link-only per the format of the surrounding entries. Happy to shorten or move it if you prefer it elsewhere.

The two extra lines in the diff are line-ending normalisation applied by the GitHub web editor, not a content change.