### PR TITLE
Add ApisKit to Next.js SaaS boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR ([How 
 
 - Agentic React Template - **Open Source** Agent-testable SaaS starter with Next.js 16 + shadcn/ui + Tailwind CSS [https://github.com/iscale-llc/agentic-react-nextjs-shadcn](https://github.com/iscale-llc/agentic-react-nextjs-shadcn) [![Stars](https://img.shields.io/github/stars/iscale-llc/agentic-react-nextjs-shadcn.svg)](https://github.com/iscale-llc/agentic-react-nextjs-shadcn)
 - All-In-One https://allinonedev.com
+- ApisKit - https://kit.apisdom.com/?utm_source=awesome-saas-boilerplates
 - Appliful - https://appliful.com/
 - Bedrock - https://bedrock.mxstbr.com/
 - BoilerPro - https://boilerpro.co


### PR DESCRIPTION
Adds ApisKit to the Next.js section.

ApisKit is a commercial Next.js SaaS starter built with Firebase and Stripe, with authentication, credits, admin panel, integrated support, ES/EN i18n, and automated verification.

Live demo: https://kit.apisdom.com/