### PR TITLE
Add Hype Stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ _Did I miss something? Do you have a boilerplate to share? -> create a PR_
 - marblism - https://www.marblism.com/
 - DirectoryKit - https://www.directorykit.xyz/
 - Horizon UI Boilerplate - https://horizon-ui.com/boilerplate
+- Hype Stack. **Open Source**. https://github.com/BetterTyped/hype-stack
 - Indie Starter Kit https://indie-starter.dev
 - SaaSBold - https://saasbold.com/
 - StartKit.AI - https://startkit.ai


### PR DESCRIPTION
## What
Add [Hype Stack](https://hype-stack.dev) to Javascript/Typescript → Node.js.

## Why
Open-source fullstack SaaS monorepo template (React + Hono + Vite). Free MIT starter; feature packs install as source into your repo.

## Links
- Site: https://hype-stack.dev
- Repo: https://github.com/BetterTyped/hype-stack
- CLI: `npx @hype-stack/cli create`